### PR TITLE
Update listener.md to remove redundant line in documentation

### DIFF
--- a/docs/en/docs/listener.md
+++ b/docs/en/docs/listener.md
@@ -15,8 +15,6 @@ To create a listener layout, you need to run the following `artisan` command in 
 php artisan orchid:listener SubtractListener
 ```
 
-This command will create a new class named `SubtractListener` in the `app/Orchid/Layouts` directory. 
-
 Running the command above will create a new class named `SubtractListener` in the `app/Orchid/Layouts` directory. 
 Once created, you can now add the required fields in the `layouts` method as shown below:
 


### PR DESCRIPTION
This PR removes a redundant line from the documentation that states, "This command will create a new class named," as this information is already clearly explained in the following paragraph. This change streamlines the documentation, enhancing readability by reducing repetition without losing clarity.